### PR TITLE
Add JSON-RPC Server Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "minimist": "1.2.8"
+    "minimist": "1.2.8",
+    "express": "^4.18.2"
   },
   "devDependencies": {
     "@types/node": "18.15.11",
+    "@types/express": "^4.17.17",
+    "@types/minimist": "^1.2.2",
     "typescript": "4.9.5"
   }
 }

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -19,7 +19,7 @@ export type ParsedArgs<V, T extends ArgsTemplate<V>> = {
 
 export type CommandRuntime<T extends { [key: string]: any }> = {
     args: ArgsTemplate<T>,
-    parser: (args: ParsedArgs<T, ArgsTemplate<T>>, sendLine: (line: string) => void) => Promise<string>
+    parser: (args: ParsedArgs<T, ArgsTemplate<T>>, sendLine: (line: string) => void) => Promise<any>
 }
 
 export type Command<T extends { [key: string]: any }> = {
@@ -88,6 +88,22 @@ export const cmdStringParser: (minLength?: number, maxLength?: number, optional?
 
 export function createCommand<T extends { [key: string]: any }>(cmd: string, description: string, runtime: CommandRuntime<T>): Command<T> {
     return { cmd, description, runtime };
+}
+
+/**
+ * Formats a structured response for CLI display
+ */
+export function formatResponseForCli(response: any): string {
+    if (typeof response === 'string') {
+        return response;
+    }
+    
+    if (typeof response === 'object' && response !== null) {
+        // For objects, create a human-readable format
+        return JSON.stringify(response, null, 2);
+    }
+    
+    return String(response);
 }
 
 export class CommandHandler {
@@ -249,7 +265,9 @@ export class CommandHandler {
             }
         }
 
-        return cmd.runtime.parser(paramsObj, (line: string) => socket.write(line+"\n"));
+        return cmd.runtime.parser(paramsObj, (line: string) => socket.write(line+"\n")).then(commandResult => {
+            return formatResponseForCli(commandResult);
+        });
 
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./Utils";
 export * from "./commands/CommandHandler";
 export * from "./config/Config";
 export * from "./rpc/JsonRpcServer";
+export * from "./tcp-cli/TcpCliServer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./Utils";
 export * from "./commands/CommandHandler";
 export * from "./config/Config";
+export * from "./rpc/JsonRpcServer";

--- a/src/rpc/JsonRpcServer.ts
+++ b/src/rpc/JsonRpcServer.ts
@@ -1,0 +1,296 @@
+import * as express from "express";
+import { Server } from "http";
+import { Command } from "../commands/CommandHandler";
+
+/**
+ * JSON-RPC 2.0 protocol types and interfaces
+ */
+
+export interface JsonRpcRequest {
+    jsonrpc: "2.0";
+    method: string;
+    params?: any[] | Record<string, any>;
+    id?: string | number | null;
+}
+
+export interface JsonRpcSuccessResponse {
+    jsonrpc: "2.0";
+    result: any;
+    id: string | number | null;
+}
+
+export interface JsonRpcError {
+    code: number;
+    message: string;
+    data?: any;
+}
+
+export interface JsonRpcErrorResponse {
+    jsonrpc: "2.0";
+    error: JsonRpcError;
+    id: string | number | null;
+}
+
+export type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;
+
+// Standard JSON-RPC 2.0 error codes
+export const JsonRpcErrorCodes = {
+    PARSE_ERROR: -32700,
+    INVALID_REQUEST: -32600,
+    METHOD_NOT_FOUND: -32601,
+    INVALID_PARAMS: -32602,
+    INTERNAL_ERROR: -32603,
+    SERVER_ERROR: -32000
+} as const;
+
+export interface RpcConfig {
+    address: string;
+    port: number;
+}
+
+
+export class JsonRpcServer {
+    private app: express.Express;
+    private server: Server | null = null;
+    private commands: { [key: string]: Command<any> };
+    private config: RpcConfig;
+
+    constructor(commands: { [key: string]: Command<any> }, config: RpcConfig) {
+        this.commands = commands;
+        this.config = config;
+        this.app = express();
+        this.setupMiddlewares();
+        this.setupRoutes();
+    }
+
+    private setupMiddlewares(): void {
+        // JSON parsing
+        this.app.use(express.json());
+
+        // JSON parsing error handler
+        this.app.use((error: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+            if (error instanceof SyntaxError && 'body' in error) {
+                return res.json({
+                    jsonrpc: "2.0",
+                    error: {
+                        code: JsonRpcErrorCodes.PARSE_ERROR,
+                        message: "Parse error"
+                    },
+                    id: null
+                });
+            }
+            next(error);
+        });
+    }
+
+    private setupRoutes(): void {
+        this.app.post('/rpc', async (req: express.Request, res: express.Response) => {
+            try {
+                const response = await this.handleJsonRpcRequest(req.body);
+                res.json(response);
+            } catch (error) {
+                console.error('JsonRpcServer: Unexpected error:', error);
+                res.json({
+                    jsonrpc: "2.0",
+                    error: {
+                        code: JsonRpcErrorCodes.INTERNAL_ERROR,
+                        message: "Internal error",
+                        data: error instanceof Error ? error.message : String(error)
+                    },
+                    id: null
+                });
+            }
+        });
+
+        // Health check endpoint
+        this.app.get('/health', (req: express.Request, res: express.Response) => {
+            res.json({ status: 'ok' });
+        });
+    }
+
+    private async handleJsonRpcRequest(body: any): Promise<JsonRpcResponse> {
+        // Check for batch requests (not supported in v1)
+        if (Array.isArray(body)) {
+            return {
+                jsonrpc: "2.0",
+                error: {
+                    code: JsonRpcErrorCodes.INVALID_REQUEST,
+                    message: "Batch requests not supported"
+                },
+                id: null
+            };
+        }
+
+        // Validate JSON-RPC 2.0 request format
+        if (!this.isValidJsonRpcRequest(body)) {
+            return {
+                jsonrpc: "2.0",
+                error: {
+                    code: JsonRpcErrorCodes.INVALID_REQUEST,
+                    message: "Invalid Request"
+                },
+                id: (body && body.id !== undefined) ? body.id : null
+            };
+        }
+
+        const request = body as JsonRpcRequest;
+        const { method, params, id } = request;
+
+        // Check if method exists
+        const command = this.commands[method];
+        if (!command) {
+            return {
+                jsonrpc: "2.0",
+                error: {
+                    code: JsonRpcErrorCodes.METHOD_NOT_FOUND,
+                    message: "Method not found"
+                },
+                id
+            };
+        }
+
+        try {
+            // Parse parameters using the command's argument parser
+            const parsedArgs = this.parseCommandParams(command, params);
+            
+            // Execute the command with a no-op sendLine callback
+            const result = await command.runtime.parser(parsedArgs, () => {});
+            
+            return {
+                jsonrpc: "2.0",
+                result,
+                id
+            };
+        } catch (error) {
+            console.error(`JsonRpcServer: Command '${method}' execution error:`, error);
+            
+            // Check if it's a parameter parsing error
+            if (error instanceof Error && error.message.includes('Parsing parameter')) {
+                return {
+                    jsonrpc: "2.0",
+                    error: {
+                        code: JsonRpcErrorCodes.INVALID_PARAMS,
+                        message: "Invalid params",
+                        data: error.message
+                    },
+                    id
+                };
+            }
+            
+            // General server error
+            return {
+                jsonrpc: "2.0",
+                error: {
+                    code: JsonRpcErrorCodes.SERVER_ERROR,
+                    message: "Server error",
+                    data: error instanceof Error ? error.message : String(error)
+                },
+                id
+            };
+        }
+    }
+
+    private isValidJsonRpcRequest(body: any): body is JsonRpcRequest {
+        return (
+            body &&
+            typeof body === 'object' &&
+            body.jsonrpc === "2.0" &&
+            typeof body.method === 'string' &&
+            (body.params === undefined || Array.isArray(body.params) || 
+             (typeof body.params === 'object' && body.params !== null)) &&
+            (body.id === undefined || body.id === null || 
+             typeof body.id === 'string' || typeof body.id === 'number')
+        );
+    }
+
+    private parseCommandParams(command: Command<any>, params: any): any {
+        const paramsObj: any = {};
+        
+        if (!params) {
+            // No parameters provided - try to parse with empty values
+            for (const key in command.runtime.args) {
+                try {
+                    paramsObj[key] = command.runtime.args[key].parser(undefined as any);
+                } catch (e) {
+                    throw new Error(`Parsing parameter '${key}': ${e instanceof Error ? e.message : String(e)}`);
+                }
+            }
+            return paramsObj;
+        }
+
+        if (Array.isArray(params)) {
+            // Positional parameters - map to base arguments in order
+            const baseArgs = Object.keys(command.runtime.args)
+                .filter(key => command.runtime.args[key].base);
+            
+            for (let i = 0; i < baseArgs.length && i < params.length; i++) {
+                const key = baseArgs[i];
+                try {
+                    paramsObj[key] = command.runtime.args[key].parser(params[i]);
+                } catch (e) {
+                    throw new Error(`Parsing parameter '${key}': ${e instanceof Error ? e.message : String(e)}`);
+                }
+            }
+            
+            // Parse remaining non-base parameters with undefined (will use defaults or fail)
+            for (const key in command.runtime.args) {
+                if (!command.runtime.args[key].base && !(key in paramsObj)) {
+                    try {
+                        paramsObj[key] = command.runtime.args[key].parser(undefined as any);
+                    } catch (e) {
+                        throw new Error(`Parsing parameter '${key}': ${e instanceof Error ? e.message : String(e)}`);
+                    }
+                }
+            }
+        } else if (typeof params === 'object') {
+            // Named parameters
+            for (const key in command.runtime.args) {
+                try {
+                    paramsObj[key] = command.runtime.args[key].parser(params[key]);
+                } catch (e) {
+                    throw new Error(`Parsing parameter '${key}': ${e instanceof Error ? e.message : String(e)}`);
+                }
+            }
+        } else {
+            throw new Error('Parameters must be an array or object');
+        }
+
+        return paramsObj;
+    }
+
+    async start(): Promise<void> {
+        if (this.server) {
+            throw new Error('JsonRpcServer: Server already started');
+        }
+
+        return new Promise<void>((resolve, reject) => {
+            this.server = this.app.listen(this.config.port, this.config.address, () => {
+                console.log(`JsonRpcServer: JSON-RPC server listening on ${this.config.address}:${this.config.port}`);
+                resolve();
+            });
+
+            this.server.on('error', (error: any) => {
+                console.error('JsonRpcServer: Server error:', error);
+                reject(error);
+            });
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.server) {
+            return;
+        }
+
+        return new Promise<void>((resolve) => {
+            this.server!.close(() => {
+                console.log('JsonRpcServer: Server stopped');
+                this.server = null;
+                resolve();
+            });
+        });
+    }
+
+    isRunning(): boolean {
+        return this.server !== null;
+    }
+}

--- a/src/tcp-cli/TcpCliServer.ts
+++ b/src/tcp-cli/TcpCliServer.ts
@@ -1,0 +1,179 @@
+import {createServer, Server, Socket} from "net";
+import {createInterface} from "readline";
+import { Command } from "../commands/CommandHandler";
+import * as minimist from "minimist";
+
+/**
+ * Formats a structured response for CLI display
+ */
+function formatResponseForCli(response: any): string {
+    if (typeof response === 'string') {
+        return response;
+    }
+    
+    if (typeof response === 'object' && response !== null) {
+        // For objects, create a human-readable format
+        return JSON.stringify(response, null, 2);
+    }
+    
+    return String(response);
+}
+
+export interface TcpCliConfig {
+    address: string;
+    port: number;
+    introMessage: string;
+}
+
+export class TcpCliServer {
+    private server: Server | null = null;
+    private commands: { [key: string]: Command<any> };
+    private config: TcpCliConfig;
+
+    constructor(commands: { [key: string]: Command<any> }, config: TcpCliConfig) {
+        this.commands = commands;
+        this.config = config;
+    }
+
+    async start(): Promise<void> {
+        if (this.server) {
+            throw new Error('TcpCliServer: Server already started');
+        }
+
+        this.server = createServer((socket) => {
+            socket.write(this.config.introMessage + "\n");
+            socket.write("Type 'help' to get a summary of existing commands!\n> ");
+
+            const rl = createInterface({input: socket});
+            rl.on("line", (line) => {
+                this.parseLine(line, socket).then(result => {
+                    socket.write(result + "\n> ");
+                }).catch(err => {
+                    console.error(err);
+                    socket.write("Error: " + (err.message != null ? err.message : JSON.stringify(err)) + "\n> ");
+                });
+            });
+
+            socket.on("error", (err) => {
+                console.error("TcpCliServer: Socket error: ", err);
+            });
+        });
+
+        return new Promise<void>((resolve, reject) => {
+            this.server!.listen(this.config.port, this.config.address, () => {
+                console.log(`TcpCliServer: TCP CLI server listening on ${this.config.address}:${this.config.port}`);
+                resolve();
+            });
+
+            this.server!.on('error', (error: any) => {
+                console.error('TcpCliServer: Server error:', error);
+                reject(error);
+            });
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.server) {
+            return;
+        }
+
+        return new Promise<void>((resolve) => {
+            this.server!.close(() => {
+                console.log('TcpCliServer: Server stopped');
+                this.server = null;
+                resolve();
+            });
+        });
+    }
+
+    isRunning(): boolean {
+        return this.server !== null;
+    }
+
+    private getUsageString(cmd: Command<any>): string {
+        const args = [];
+        for(let key in cmd.runtime.args) {
+            if (cmd.runtime.args[key].base) {
+                args.push("<"+key+">");
+            }
+        }
+        return cmd.cmd+" "+args.join(" ");
+    }
+
+    private getParamsDescription(cmd: Command<any>): string[] {
+        const params = [];
+        for(let key in cmd.runtime.args) {
+            params.push("--"+key+" : "+cmd.runtime.args[key].description);
+        }
+        return params;
+    }
+
+    private getCommandHelp(cmd: Command<any>): string {
+        const lines = [
+            "Command: "+cmd.cmd,
+            "Description: "+cmd.description,
+            "Usage: "+this.getUsageString(cmd)
+        ];
+
+        const paramLines = this.getParamsDescription(cmd);
+        if(paramLines.length!==0) lines.push("Params:");
+        paramLines.forEach(param => {
+            lines.push("    "+param);
+        });
+
+        return lines.join("\n");
+    }
+
+    private getHelp(): string {
+        const lines = ["Available commands:"];
+        for(let key in this.commands) {
+            lines.push("    "+key+" : "+this.commands[key].description);
+        }
+        lines.push("Use 'help <command name>' for usage examples, description & help around a specific command!");
+        return lines.join("\n");
+    }
+
+    private parseLine(line: string, socket: Socket): Promise<string> {
+        if(line==="") return Promise.resolve("");
+        const regex = new RegExp('"[^"]+"|[\\S]+', 'g');
+        const args = [];
+        line.match(regex).forEach(element => {
+            if (!element) return;
+            return args.push(element.replace(/"/g, ''));
+        });
+
+        if(args[0]==="help") {
+            if(args[1]!=null && this.commands[args[1]]!=null) {
+                return Promise.resolve(this.getCommandHelp(this.commands[args[1]]));
+            }
+            return Promise.resolve(this.getHelp());
+        }
+
+        const cmd = this.commands[args[0]];
+
+        if(cmd==null) {
+            return Promise.resolve("Error: Unknown command, please type 'help' to get a list of all commands!");
+        }
+
+        const result = minimist(args, {string: ["_"].concat(Object.keys(cmd.runtime.args))}); //Treat all keys as string
+
+        const paramsObj: any = {};
+
+        let index = 1;
+        for(let key in cmd.runtime.args) {
+            if(cmd.runtime.args[key].base) {
+                if(result[key]==null && result._[index]!=null) result[key] = result._[index];
+                index++;
+            }
+            try {
+                paramsObj[key] = cmd.runtime.args[key].parser(result[key]);
+            } catch (e) {
+                return Promise.resolve("Error: Parsing parameter '"+key+"': "+e.message+"\n\n"+this.getCommandHelp(cmd));
+            }
+        }
+
+        return cmd.runtime.parser(paramsObj, (line: string) => socket.write(line+"\n")).then(commandResult => {
+            return formatResponseForCli(commandResult);
+        });
+    }
+}


### PR DESCRIPTION
This PR adds JSON-RPC 2.0 server support to enable standardized API access across Atomiq services. The implementation includes a complete JSON-RPC server with proper error handling, request validation, and Express.js integration. With this change the CLI also answers in JSON.

Adds: 
- JsonRpcServer class with full JSON-RPC 2.0 protocol support.
- TCP CLI server enhancements, and Express.js dependency for HTTP server capabilities. 
- Includes comprehensive error codes and response handling.
- Help endpoint not implemented in RPC

Linked to [atomiq-relay#9](https://github.com/atomiqlabs/atomiq-relay/pull/9) and [atomiq-lp#12](https://github.com/atomiqlabs/atomiq-lp/pull/12).